### PR TITLE
Fix jq call to allow output to be piped into another command

### DIFF
--- a/deployments/01-docker-local/03-test-deployment.sh
+++ b/deployments/01-docker-local/03-test-deployment.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 SERVICE_URL=http://localhost:3000
-curl -s ${SERVICE_URL} | jq
+curl -s ${SERVICE_URL} | jq .

--- a/deployments/02-kubernetes-minikube/04-test-deployment.sh
+++ b/deployments/02-kubernetes-minikube/04-test-deployment.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 SERVICE_URL=$(minikube ip)
-curl -s ${SERVICE_URL} | jq
+curl -s ${SERVICE_URL} | jq .

--- a/deployments/03-kubernetes-gcp-cli/07-test-deployment.sh
+++ b/deployments/03-kubernetes-gcp-cli/07-test-deployment.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 SERVICE_URL=$(kubectl get ing --output='jsonpath={.items[].status.loadBalancer.ingress[].ip}')
-curl -s ${SERVICE_URL} | jq
+curl -s ${SERVICE_URL} | jq .

--- a/deployments/04-kubernetes-gcp-terraform/07-test-deployment.sh
+++ b/deployments/04-kubernetes-gcp-terraform/07-test-deployment.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 SERVICE_URL=$(kubectl get ing --output='jsonpath={.items[].status.loadBalancer.ingress[].ip}')
-curl -s ${SERVICE_URL} | jq
+curl -s ${SERVICE_URL} | jq .

--- a/deployments/05-kubernetes-azure-cli/07-test-deployment.sh
+++ b/deployments/05-kubernetes-azure-cli/07-test-deployment.sh
@@ -2,4 +2,4 @@
 # We will need to somehow get the URL that is exposed by the GCP external load balancer (figure out what other steps besides in deployment file)
 #                                                                                       (note: deployment file will have to be different for GCP)
 SERVICE_URL=$(kubectl get service example-app-lb -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
-curl -s ${SERVICE_URL} | jq
+curl -s ${SERVICE_URL} | jq .


### PR DESCRIPTION
`jq` behaves differently when it's writing to a TTY.